### PR TITLE
Update license note

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ GOES-VFI uses a standardized configuration mechanism for core settings:
 
 ## License
 
-This project does not currently have a license. Consider adding one (e.g., MIT License).
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
- mention MIT license in the README

## Testing
- `python3 run_linters.py`
- `python3 run_non_gui_tests.py` *(fails: ModuleNotFoundError: No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_68572d25687083208c1d2768a6872510