### PR TITLE
Fix outdated test script references in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **UI Enhancement:** Added more robust button handling to ensure Start button click events are properly processed
 - **Diagnostic:** Added extensive debug logging throughout the application for better troubleshooting
-- **GUI:** Created new test helper scripts for more reliable testing (`run_fixed_gui_tests.py`, `run_fixed_integration_tests.py`, `run_non_gui_tests.py`, `run_working_tests.py`)
+- **GUI:** Created new test helper scripts for more reliable testing (`run_working_tests_with_mocks.py`, `run_non_gui_tests.py`)
 - **Processing:** Added `ImageSaver` class to properly implement saving functionality for processed images
 - **Documentation:** Added detailed documentation of settings persistence issues and potential fixes (`docs/settings_persistence_issues.md`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,9 +16,9 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-## Build, Lint & Test Commands
-- Run working tests only: `./run_working_tests.py`
-- Run fixed GUI tests only: `./run_fixed_gui_tests.py`
+-## Build, Lint & Test Commands
+- Run working tests only: `./run_working_tests_with_mocks.py`
+- Run non-GUI tests only: `./run_non_gui_tests.py`
 - Run all tests: `./run_all_tests.py`
 - Run a single test: `python -m pytest tests/path/to/test_file.py`
 - Run a specific test function: `python -m pytest tests/path/to/test_file.py::test_function_name`
@@ -44,8 +44,8 @@ The project uses a comprehensive linting setup with multiple tools:
 - MyPy strict mode: `python run_linters.py --mypy-only --strict`
 
 Note: Some tests may fail due to recent refactoring. When testing new changes:
-- Use `run_working_tests.py` for non-GUI tests
-- Use `run_fixed_gui_tests.py` for GUI tests (avoids segmentation faults)
+- Use `run_working_tests_with_mocks.py` for reliable tests
+- Use `run_non_gui_tests.py` to avoid segmentation faults
 - PyQt GUI tests are prone to segmentation faults - be careful when running all GUI tests at once
 
 ## Project Structure and Organization
@@ -122,8 +122,8 @@ This ensures examples can be run from any directory while properly accessing the
 
 ### Test Runner Scripts
 Multiple test runners are provided for different testing scenarios:
-- `run_working_tests.py`: Only runs reliable non-GUI tests
-- `run_fixed_gui_tests.py`: Runs GUI tests with extra safeguards to prevent segfaults
+- `run_working_tests_with_mocks.py`: Runs reliable tests with missing dependencies mocked
+- `run_non_gui_tests.py`: Executes all tests except the GUI suite
 - `run_all_tests.py`: Complete test suite (use with caution due to GUI test instability)
 
 ## Known Test Issues

--- a/DIRECTORY_STRUCTURE.md
+++ b/DIRECTORY_STRUCTURE.md
@@ -88,8 +88,7 @@ This document provides an overview of the directory structure for the GOES VFI p
 ## Test Runner Scripts
 
 - **[run_all_tests.py](run_all_tests.py)**: Script to run all tests
-- **[run_fixed_gui_tests.py](run_fixed_gui_tests.py)**: Script to run only fixed GUI tests
-- **[run_working_tests.py](run_working_tests.py)**: Script to run only working tests
-- **[run_fixed_integration_tests.py](run_fixed_integration_tests.py)**: Script to run integration tests
-- **[run_non_gui_tests.py](run_non_gui_tests.py)**: Script to run non-GUI tests
+- **[run_working_tests_with_mocks.py](run_working_tests_with_mocks.py)**: Runs reliable tests with dependencies mocked
+- **[run_non_gui_tests.py](run_non_gui_tests.py)**: Script to run tests excluding GUI
+- **[run_non_gui_tests_ci.py](run_non_gui_tests_ci.py)**: CI variant for headless environments
 - **[run_mypy_checks.py](run_mypy_checks.py)**: Script to run mypy type checking

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The GOES-VFI project is organized with a clean directory structure to make the c
 
 ### Development Tools
 - `scripts/`: Development and utility scripts
-- `run_all_tests.py`, `run_working_tests.py`, etc.: Test runner scripts
+- `run_all_tests.py`, `run_working_tests_with_mocks.py`, `run_non_gui_tests.py`, etc.: Test runner scripts
 - `cleanup.py`: Script to clean up temporary and cache files
 
 ## Examples and Testing
@@ -217,11 +217,11 @@ The project uses pytest for unit testing, integration testing, and GUI testing. 
 To run the tests, use one of the test runner scripts:
 
 ```bash
-# Run all working tests
-./run_working_tests.py
+# Run all working tests with mocks
+./run_working_tests_with_mocks.py
 
-# Run fixed GUI tests
-./run_fixed_gui_tests.py
+# Run non-GUI tests
+./run_non_gui_tests.py
 
 # Run all tests
 ./run_all_tests.py

--- a/tests/README.md
+++ b/tests/README.md
@@ -27,8 +27,8 @@ This directory contains the organized test structure for the GOES VFI project. T
 
 The project includes multiple test runner scripts for different testing scenarios:
 
-- **run_working_tests.py**: Only runs reliable, non-GUI tests
-- **run_fixed_gui_tests.py**: Runs GUI tests with extra safeguards to prevent segfaults
+- **run_working_tests_with_mocks.py**: Only runs reliable tests with missing dependencies mocked
+- **run_non_gui_tests.py**: Runs all tests except GUI tests
 - **run_all_tests.py**: Complete test suite (use with caution due to GUI test instability)
 
 ## Running Tests
@@ -60,10 +60,10 @@ python -m pytest tests/unit/test_main_tab.py::test_initial_state
 python -m pytest tests/unit/test_config.py -v
 ```
 
-### Running Only Fixed GUI Tests
+### Running Non-GUI Tests
 ```bash
-# Run only GUI tests that have been fixed and don't cause segmentation faults
-./run_fixed_gui_tests.py
+# Run tests excluding the GUI suite
+./run_non_gui_tests.py
 ```
 
 ## GUI Testing Issues


### PR DESCRIPTION
## Summary
- update README with correct test runner script names
- refresh CLAUDE and tests docs with new script references
- update directory structure and changelog

## Testing
- `python run_working_tests_with_mocks.py` *(fails: AttributeError: type object 'MockQSettings' has no attribute 'Format')*

------
https://chatgpt.com/codex/tasks/task_e_685731f6a17883208323b732661c0680