### PR TITLE
Replace debug prints with logger

### DIFF
--- a/goesvfi/gui.py
+++ b/goesvfi/gui.py
@@ -1913,26 +1913,24 @@ class MainWindow(QWidget):
             return
 
         # Enhanced debugging output
-        print("\n========== MAIN WINDOW HANDLER CALLED ==========")
-        print("MainWindow._handle_processing received the signal")
-        LOGGER.info(
-            "MainWindow: _handle_processing called - Starting video interpolation processing"
-        )
+        LOGGER.debug("========== MAIN WINDOW HANDLER CALLED ==========")
+        LOGGER.debug("MainWindow._handle_processing received the signal")
+        LOGGER.info("MainWindow: _handle_processing called - Starting video interpolation processing")
 
-        # Print detailed argument info
-        print(f"Received args dictionary with {len(args) if args else 0} keys")
+        # Log detailed argument info
+        LOGGER.debug("Received args dictionary with %s keys", len(args) if args else 0)
         if args:
-            print(f"Args keys: {list(args.keys())}")
-            print(f"In directory: {args.get('in_dir')}")
-            print(f"Out file: {args.get('out_file')}")
+            LOGGER.debug("Args keys: %s", list(args.keys()))
+            LOGGER.debug("In directory: %s", args.get("in_dir"))
+            LOGGER.debug("Out file: %s", args.get("out_file"))
         else:
-            print("WARNING: Empty args dictionary received!")
+            LOGGER.warning("Empty args dictionary received!")
             return
 
         LOGGER.debug("Processing arguments: %s", args)
 
         # Update UI state
-        print("Updating UI state: setting is_processing = True")
+        LOGGER.debug("Updating UI state: setting is_processing = True")
         self.is_processing = True
 
         # If a previous worker is still running, terminate it

--- a/goesvfi/pipeline/raw_encoder.py
+++ b/goesvfi/pipeline/raw_encoder.py
@@ -9,15 +9,17 @@ import numpy as np
 from numpy.typing import NDArray
 from PIL import Image
 
+from goesvfi.utils import log
+
+LOGGER = log.get_logger(__name__)
+
 # Define FloatNDArray alias if needed, or import if defined elsewhere
 # Assuming FloatNDArray = NDArray[np.float32] for consistency
 FloatNDArray = NDArray[np.float32]
 
 
 # Renamed from write_mp4
-def write_raw_mp4(
-    frames: Iterable[FloatNDArray], raw_path: pathlib.Path, fps: int
-) -> pathlib.Path:
+def write_raw_mp4(frames: Iterable[FloatNDArray], raw_path: pathlib.Path, fps: int) -> pathlib.Path:
     """
     Writes intermediate MP4 with a lossless codec (FFV1).
     Returns the path to raw_path.
@@ -28,12 +30,12 @@ def write_raw_mp4(
     # Ensure directory exists
     pattern.parent.mkdir(parents=True, exist_ok=True)
 
-    print(f"Writing frames to temporary PNGs in {tmpdir.name}...")
+    LOGGER.info("Writing frames to temporary PNGs in %s...", tmpdir.name)
     for i, frm in enumerate(frames):
         img8: NDArray[np.uint8] = (np.clip(frm, 0, 1) * 255).astype(np.uint8)
         Image.fromarray(img8).save(pattern.parent / f"{i:06d}.png")
 
-    print(f"Encoding frames to lossless MP4: {raw_path}")
+    LOGGER.info("Encoding frames to lossless MP4: %s", raw_path)
     # Use subprocess for ffmpeg command
     cmd = [
         "ffmpeg",
@@ -48,22 +50,22 @@ def write_raw_mp4(
     ]
     try:
         subprocess.run(cmd, check=True, capture_output=True, text=True, timeout=120)
-        print("Lossless encoding successful.")
+        LOGGER.info("Lossless encoding successful.")
     except subprocess.CalledProcessError as e:
         pass
-        print("FFmpeg (raw) error:")
-        print(f"STDOUT: {e.stdout}")
-        print(f"STDERR: {e.stderr}")
+        LOGGER.error("FFmpeg (raw) error:")
+        LOGGER.error("STDOUT: %s", e.stdout)
+        LOGGER.error("STDERR: %s", e.stderr)
         # Clean up temp dir even on error
         tmpdir.cleanup()
         raise  # Re-raise the exception
     except FileNotFoundError:
         pass
-        print("Error: ffmpeg command not found. Is ffmpeg installed and in your PATH?")
+        LOGGER.error("Error: ffmpeg command not found. Is ffmpeg installed and in your PATH?")
         tmpdir.cleanup()
         raise
 
     # Clean up temporary directory
     tmpdir.cleanup()
-    print(f"Temporary PNGs cleaned up. Raw MP4 created at: {raw_path}")
+    LOGGER.info("Temporary PNGs cleaned up. Raw MP4 created at: %s", raw_path)
     return raw_path  # Return the path

--- a/goesvfi/pipeline/run_vfi.py
+++ b/goesvfi/pipeline/run_vfi.py
@@ -392,7 +392,6 @@ def _encode_frame_to_png_bytes(img: Image.Image) -> bytes:
 # Helper function for safe writing to ffmpeg stdin with detailed error logging
 def _safe_write(proc: subprocess.Popen[bytes], data: bytes, frame_desc: str) -> None:
     """Writes data to process stdin, handles BrokenPipeError with stderr logging."""
-    # print(f"DEBUG _safe_write: Called for '{frame_desc}', data length: {len(data)}, proc.stdin id: {id(proc.stdin) if proc.stdin else 'None'}") # DEBUG
     if proc.stdin is None:
         LOGGER.error(f"Cannot write {frame_desc}: ffmpeg stdin is None.")
         stderr_bytes = b""


### PR DESCRIPTION
## Summary
- use goesvfi.utils.log.get_logger in the GUI
- log encoder progress in raw_encoder.py
- drop stale debug comment in run_vfi
- enhance MockQSettings and provide simple Qt stubs for running tests without PyQt6

## Testing
- `python run_linters.py goesvfi/gui.py goesvfi/pipeline/raw_encoder.py goesvfi/pipeline/run_vfi.py`
- `python run_working_tests_with_mocks.py`

------
https://chatgpt.com/codex/tasks/task_e_6857322b52c8832087c666a6bf68437b