### PR TITLE
Replace debug prints with logger

### DIFF
--- a/goesvfi/gui.py
+++ b/goesvfi/gui.py
@@ -1913,26 +1913,24 @@ class MainWindow(QWidget):
             return
 
         # Enhanced debugging output
-        print("\n========== MAIN WINDOW HANDLER CALLED ==========")
-        print("MainWindow._handle_processing received the signal")
-        LOGGER.info(
-            "MainWindow: _handle_processing called - Starting video interpolation processing"
-        )
+        LOGGER.debug("========== MAIN WINDOW HANDLER CALLED ==========")
+        LOGGER.debug("MainWindow._handle_processing received the signal")
+        LOGGER.info("MainWindow: _handle_processing called - Starting video interpolation processing")
 
-        # Print detailed argument info
-        print(f"Received args dictionary with {len(args) if args else 0} keys")
+        # Log detailed argument info
+        LOGGER.debug("Received args dictionary with %s keys", len(args) if args else 0)
         if args:
-            print(f"Args keys: {list(args.keys())}")
-            print(f"In directory: {args.get('in_dir')}")
-            print(f"Out file: {args.get('out_file')}")
+            LOGGER.debug("Args keys: %s", list(args.keys()))
+            LOGGER.debug("In directory: %s", args.get("in_dir"))
+            LOGGER.debug("Out file: %s", args.get("out_file"))
         else:
-            print("WARNING: Empty args dictionary received!")
+            LOGGER.warning("Empty args dictionary received!")
             return
 
         LOGGER.debug("Processing arguments: %s", args)
 
         # Update UI state
-        print("Updating UI state: setting is_processing = True")
+        LOGGER.debug("Updating UI state: setting is_processing = True")
         self.is_processing = True
 
         # If a previous worker is still running, terminate it

--- a/goesvfi/pipeline/run_vfi.py
+++ b/goesvfi/pipeline/run_vfi.py
@@ -392,7 +392,6 @@ def _encode_frame_to_png_bytes(img: Image.Image) -> bytes:
 # Helper function for safe writing to ffmpeg stdin with detailed error logging
 def _safe_write(proc: subprocess.Popen[bytes], data: bytes, frame_desc: str) -> None:
     """Writes data to process stdin, handles BrokenPipeError with stderr logging."""
-    # print(f"DEBUG _safe_write: Called for '{frame_desc}', data length: {len(data)}, proc.stdin id: {id(proc.stdin) if proc.stdin else 'None'}") # DEBUG
     if proc.stdin is None:
         LOGGER.error(f"Cannot write {frame_desc}: ffmpeg stdin is None.")
         stderr_bytes = b""


### PR DESCRIPTION
## Summary
- use goesvfi.utils.log.get_logger in the GUI
- log encoder progress in raw_encoder.py
- drop stale debug comment in run_vfi
- enhance MockQSettings and provide simple Qt stubs for running tests without PyQt6
- remove stray `pass` statements in raw_encoder error handlers

## Testing
- `python run_linters.py goesvfi/gui.py goesvfi/pipeline/raw_encoder.py goesvfi/pipeline/run_vfi.py`
- `python run_working_tests_with_mocks.py`


------
https://chatgpt.com/codex/tasks/task_e_6857322b52c8832087c666a6bf68437b