### PR TITLE
Improve testing instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,8 @@ The following guidance applies when using Codex (and other automated tools) with
 - Reliable tests with mocks: `./run_working_tests_with_mocks.py`
 - Non‑GUI tests (avoid PyQt segmentation faults): `./run_non_gui_tests.py`
 - Full test suite (may be unstable due to GUI tests): `./run_all_tests.py`
+- Always activate your virtual environment and run `pip install -r requirements.txt`
+  before executing these scripts to avoid ImportError issues (e.g. missing PyQt6).
 
 ## Repository Guidelines
 - Follow the project structure described in `DIRECTORY_STRUCTURE.md` and the

--- a/README.md
+++ b/README.md
@@ -214,7 +214,16 @@ The project uses pytest for unit testing, integration testing, and GUI testing. 
   * **Imagery Tests:** Tests for imagery-related GUI components
   * **Tab Tests:** Tests for various tab components
 
-To run the tests, use one of the test runner scripts:
+Before running the tests, make sure your virtual environment is activated and all
+dependencies are installed:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Then use one of the test runner scripts:
 
 ```bash
 # Run all working tests with mocks


### PR DESCRIPTION
## Summary
- clarify environment setup in AGENTS
- remind developers to activate a venv before running tests in README

## Testing
- `./run_working_tests_with_mocks.py`

------
https://chatgpt.com/codex/tasks/task_e_68573f9e0d7c83208e7330d2c2577895