### PR TITLE
Improve logger formatter handling

### DIFF
--- a/goesvfi/utils/log.py
+++ b/goesvfi/utils/log.py
@@ -57,27 +57,26 @@ def _build_handler() -> logging.Handler:
         )
     else:
         handler = logging.StreamHandler(sys.stdout)
-        handler.setFormatter(
-            logging.Formatter("[%(levelname).1s] %(name)s: %(message)s")
-        )
+        handler.setFormatter(logging.Formatter("[%(levelname).1s] %(name)s: %(message)s"))
     return handler
 
 
 def get_logger(name: str | None = None) -> logging.Logger:
-    """Gets a logger instance. Configuration is handled by the root logger."""
-    global _handler
+    """Return a module-specific logger with optional color formatting."""
+    global _handler, _LEVEL
+
+    # Always read the current level from config
+    _LEVEL = _get_level_from_config()
 
     logger = logging.getLogger(name)
     logger.setLevel(_LEVEL)
 
-    # Build handler if it doesn't exist
     if _handler is None:
         _handler = _build_handler()
-        _handler.setLevel(_LEVEL)
 
-    # Add handler to logger if not already present
-    handler_types = [type(h) for h in logger.handlers]
-    if type(_handler) not in handler_types:
+    _handler.setLevel(_LEVEL)
+
+    if _handler not in logger.handlers:
         logger.addHandler(_handler)
 
     return logger


### PR DESCRIPTION
## Summary
- update `get_logger` to always use `colorlog` when available
- refresh logging level from config for each call
- add short docstring

## Testing
- `black goesvfi/utils/log.py`
- `isort --check goesvfi/utils/log.py`
- `flake8 goesvfi/utils/log.py`
- `./run_non_gui_tests.py -q` *(fails: RuntimeError and AttributeError in S3 mocks)*

------
https://chatgpt.com/codex/tasks/task_e_6857a4836c0483209548ad511bc2380f