### PR TITLE
Implement VfiWorker and integrate with MainTab

### DIFF
--- a/tests/integration/test_vfi_worker_run.py
+++ b/tests/integration/test_vfi_worker_run.py
@@ -1,0 +1,56 @@
+import pathlib
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+# Provide minimal PyQt6 mocks for headless test execution
+qtcore = SimpleNamespace(QThread=object, pyqtSignal=lambda *a, **k: MagicMock())
+sys.modules.setdefault("PyQt6", SimpleNamespace(QtCore=qtcore))
+sys.modules.setdefault("PyQt6.QtCore", qtcore)
+
+from goesvfi.pipeline.run_vfi import VfiWorker
+from PIL import Image
+
+
+def create_dummy_png(path: pathlib.Path, size=(10, 10)) -> None:
+    img = Image.new("RGB", size, color=(0, 0, 0))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    img.save(path, format="PNG")
+
+
+def test_vfi_worker_run(tmp_path, monkeypatch):
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    for i in range(2):
+        create_dummy_png(input_dir / f"frame_{i}.png")
+
+    output_file = tmp_path / "out.mp4"
+
+    monkeypatch.setattr(
+        "goesvfi.pipeline.run_vfi.VfiWorker._get_rife_executable",
+        lambda self: pathlib.Path("/fake/rife"),
+    )
+
+    def fake_run_vfi(**kwargs):
+        yield (1, 2, 0.0)
+        yield pathlib.Path(kwargs["output_mp4_path"])
+
+    monkeypatch.setattr("goesvfi.pipeline.run_vfi.run_vfi", fake_run_vfi)
+
+    worker = VfiWorker(in_dir=str(input_dir), out_file_path=str(output_file))
+
+    prog = MagicMock()
+    fin = MagicMock()
+    err = MagicMock()
+
+    worker.progress.emit = prog
+    worker.finished.emit = fin
+    worker.error.emit = err
+
+    worker.run()
+
+    prog.assert_called_with(1, 2, 0.0)
+    fin.assert_called_with(str(output_file))
+    err.assert_not_called()


### PR DESCRIPTION
## Summary
- implement real run logic for VfiWorker that calls `run_vfi`
- wire MainTab to start a VfiWorker thread directly
- add helper to create/start worker and update progress
- add integration test for VfiWorker using mocked PyQt

## Testing
- `python -m pytest tests/integration/test_vfi_worker_run.py -v`
- `python run_linters.py --flake8-only --black-only --isort-only` *(fails: flake8 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6857a4c12c988320a764d9df86cc4734