### PR TITLE
Update crop sync and ffmpeg command

### DIFF
--- a/goesvfi/gui.py
+++ b/goesvfi/gui.py
@@ -758,6 +758,11 @@ class MainWindow(QWidget):
                 if not success:
                     LOGGER.error("Failed to save crop rectangle to settings!")
 
+            if hasattr(self, "ffmpeg_settings_tab") and hasattr(
+                self.ffmpeg_settings_tab, "set_crop_rect"
+            ):
+                self.ffmpeg_settings_tab.set_crop_rect(rect)
+
             # Save all settings immediately when crop rectangle changes
             # This ensures crop settings are preserved even if the app crashes
             try:
@@ -1432,6 +1437,9 @@ class MainWindow(QWidget):
         self.ffmpeg_pix_fmt_combo.setCurrentText(
             self.settings.value("ffmpeg_pix_fmt", "yuv444p", type=str)
         )
+        self.ffmpeg_settings_tab.crop_filter_edit.setText(
+            self.settings.value("ffmpeg_filter_string", "", type=str)
+        )
 
         # Update UI elements based on loaded settings
         if self.in_dir:
@@ -1766,6 +1774,14 @@ class MainWindow(QWidget):
                 self.settings.setValue(
                     "ffmpeg_pix_fmt",
                     self.ffmpeg_settings_tab.pix_fmt_combo.currentText(),
+                )
+            if (
+                hasattr(self.ffmpeg_settings_tab, "crop_filter_edit")
+                and self.ffmpeg_settings_tab.crop_filter_edit is not None
+            ):
+                self.settings.setValue(
+                    "ffmpeg_filter_string",
+                    self.ffmpeg_settings_tab.crop_filter_edit.text(),
                 )
 
     def _validate_thread_spec(self, text: str) -> None:

--- a/tests/unit/test_processing_view_model_ffmpeg.py
+++ b/tests/unit/test_processing_view_model_ffmpeg.py
@@ -1,0 +1,22 @@
+import pathlib
+
+from goesvfi.view_models.processing_view_model import ProcessingViewModel
+
+
+def test_build_ffmpeg_command_with_crop():
+    vm = ProcessingViewModel()
+    output = pathlib.Path("/tmp/out.mp4")
+    settings = {"encoder": "Software x264", "crf": 20, "pix_fmt": "yuv420p"}
+    cmd = vm.build_ffmpeg_command(output, 30, (10, 20, 100, 80), settings)
+    idx = cmd.index("-filter:v")
+    assert cmd[idx + 1].startswith("crop=100:80:10:20")
+    assert str(output) in cmd
+
+
+def test_build_ffmpeg_command_without_crop():
+    vm = ProcessingViewModel()
+    output = pathlib.Path("/tmp/out.mp4")
+    settings = {"encoder": "Software x264"}
+    cmd = vm.build_ffmpeg_command(output, 24, None, settings)
+    assert "-filter:v" not in cmd
+


### PR DESCRIPTION
## Summary
- sync crop rectangle selection with FFmpeg settings tab
- warn about conflicting crop filter
- expose helper to build FFmpeg command with cropping
- test ProcessingViewModel command creation logic

## Testing
- `python run_linters.py --format` *(fails: flake8 violations and pylint interrupted)*
- `python -m pytest tests/unit/test_processing_view_model_ffmpeg.py -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6857a4c711808320867e628e9c0339b0