### PR TITLE
Use settings provider in batch tab

### DIFF
--- a/goesvfi/gui_tabs/batch_processing_tab.py
+++ b/goesvfi/gui_tabs/batch_processing_tab.py
@@ -45,6 +45,7 @@ class BatchProcessingTab(QWidget):
         self,
         process_function: Optional[Callable[..., Any]] = None,
         resource_manager: Optional[Any] = None,
+        settings_provider: Optional[Callable[[], Dict[str, Any]]] = None,
     ) -> None:
         """Initialize batch processing tab."""
         super().__init__()
@@ -53,6 +54,7 @@ class BatchProcessingTab(QWidget):
         self.resource_manager = resource_manager
         self.batch_processor = BatchProcessor(resource_manager)
         self.batch_queue: Optional[BatchQueue] = None
+        self.settings_provider = settings_provider
 
         self._init_ui()
         self._init_batch_queue()
@@ -258,12 +260,14 @@ class BatchProcessingTab(QWidget):
         output_dir = Path(self.output_dir_label.text())
         priority = self.priority_combo.currentData()
 
-        # TODO: Get actual processing settings from main tab
-        settings = {
-            "target_fps": 30,
-            "skip_ai": False,
-            # Add more settings as needed
-        }
+        if self.settings_provider:
+            try:
+                settings = self.settings_provider()
+            except Exception as exc:  # pragma: no cover - defensive
+                LOGGER.exception("Failed to obtain settings: %s", exc)
+                settings = {}
+        else:
+            settings = {}
 
         job_ids = []
 

--- a/tests/unit/test_batch_processing_tab.py
+++ b/tests/unit/test_batch_processing_tab.py
@@ -1,0 +1,78 @@
+from unittest.mock import patch
+
+import pytest
+
+from goesvfi.gui_tabs.batch_processing_tab import BatchProcessingTab
+from goesvfi.pipeline.batch_queue import BatchJob, JobPriority
+
+
+class DummySignal:
+    def connect(self, *args, **kwargs):
+        pass
+
+
+class DummyQueue:
+    def __init__(self) -> None:
+        self.jobs = []
+        self.job_added = DummySignal()
+        self.job_started = DummySignal()
+        self.job_progress = DummySignal()
+        self.job_completed = DummySignal()
+        self.job_failed = DummySignal()
+        self.job_cancelled = DummySignal()
+        self.queue_empty = DummySignal()
+
+    def add_job(self, job: BatchJob) -> None:
+        self.jobs.append(job)
+
+    def get_all_jobs(self):
+        return self.jobs
+
+
+@pytest.fixture
+def batch_tab(qtbot):
+    dummy_queue = DummyQueue()
+    selected_settings = {"target_fps": 24, "interpolation": "RIFE"}
+
+    def provider():
+        return selected_settings
+
+    with patch("goesvfi.gui_tabs.batch_processing_tab.BatchProcessor") as MockProc, patch(
+        "goesvfi.gui_tabs.batch_processing_tab.QMessageBox"
+    ):
+        proc_instance = MockProc.return_value
+        proc_instance.create_queue.return_value = dummy_queue
+
+        def fake_create_job_from_paths(input_paths, output_dir, settings, priority=JobPriority.NORMAL, **_):
+            return [
+                BatchJob(
+                    id="job1",
+                    name="Test",
+                    input_path=input_paths[0],
+                    output_path=output_dir / input_paths[0].name,
+                    settings=settings,
+                    priority=priority,
+                )
+            ]
+
+        proc_instance.create_job_from_paths.side_effect = fake_create_job_from_paths
+
+        tab = BatchProcessingTab(
+            process_function=lambda *_: None,
+            settings_provider=provider,
+        )
+        qtbot.addWidget(tab)
+
+    return tab, dummy_queue, selected_settings, proc_instance
+
+
+def test_add_to_queue_uses_current_settings(batch_tab):
+    tab, queue, expected_settings, proc = batch_tab
+    tab.output_dir_label.setText("/tmp/output")
+    tab.input_paths_list.addItem("/tmp/input/file1.png")
+
+    tab._add_to_queue()
+
+    assert len(queue.jobs) == 1
+    assert queue.jobs[0].settings == expected_settings
+    proc.create_job_from_paths.assert_called_once()


### PR DESCRIPTION
## Summary
- accept a settings_provider callable in `BatchProcessingTab`
- use provided settings in `_add_to_queue`
- add unit test verifying settings are passed to jobs

## Testing
- `python run_linters.py --isort-only --format`
- `python run_linters.py --flake8-only`
- `QT_QPA_PLATFORM=offscreen python -m pytest tests/unit/test_batch_processing_tab.py -vv` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6857a4b934008320b13989d533009c2d