### PR TITLE
Implement optimized array chunking

### DIFF
--- a/docs/api/utils.rst
+++ b/docs/api/utils.rst
@@ -357,6 +357,10 @@ Automatic memory optimization:
        processed = optimizer.process_with_optimization(data_chunk)
        yield processed
 
+   # Process a large array in small pieces
+   for chunk in optimizer.optimize_array_chunks(large_array, max_chunk_mb=64):
+       heavy_compute(chunk)
+
 **Monitoring Functions:**
 
 .. autofunction:: memory_manager.get_memory_monitor


### PR DESCRIPTION
## Summary
- add `optimize_array_chunks` to `MemoryOptimizer`
- use optimized chunking in `StreamingProcessor`
- document chunk optimization example
- test optimized chunks and streaming processor memory use

## Testing
- `python run_linters.py --flake8-only`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_memory_management.py::test_optimize_array_chunks_no_shared_memory -v`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_memory_management.py::test_streaming_processor_low_memory_usage -v`


------
https://chatgpt.com/codex/tasks/task_e_6857a49b16808320917c6b40df95d0e7