### PR TITLE
Catch specific errors in netcdf renderer

### DIFF
--- a/goesvfi/integrity_check/render/netcdf.py
+++ b/goesvfi/integrity_check/render/netcdf.py
@@ -274,11 +274,15 @@ def render_png(
             LOGGER.debug("Rendered %s", final_output_path)
             return final_output_path
 
-    # TODO: Replace with specific exceptions: KeyError, RuntimeError, ValueError
-
-    except Exception as e:
+    except KeyError as e:
         LOGGER.exception("Error occurred: %s", e)
-        raise IOError(f"Error rendering NetCDF file: {e}") from e
+        raise KeyError(f"Error rendering NetCDF file: {e}") from e
+    except RuntimeError as e:
+        LOGGER.exception("Error occurred: %s", e)
+        raise RuntimeError(f"Error rendering NetCDF file: {e}") from e
+    except ValueError as e:
+        LOGGER.exception("Error occurred: %s", e)
+        raise ValueError(f"Error rendering NetCDF file: {e}") from e
 
 
 def extract_metadata(netcdf_path: Union[str, Path]) -> Dict[str, Any]:
@@ -318,8 +322,12 @@ def extract_metadata(netcdf_path: Union[str, Path]) -> Dict[str, Any]:
                 "resolution_y": ds[Y_VAR].size if Y_VAR in ds.variables else None,
             }
             return metadata
-    # TODO: Replace with specific exceptions: KeyError, RuntimeError, ValueError
-
-    except Exception as e:
+    except KeyError as e:
+        LOGGER.exception("Error occurred: %s", e)
+        raise KeyError("Error extracting metadata: %s" % e) from e
+    except RuntimeError as e:
+        LOGGER.exception("Error occurred: %s", e)
+        raise RuntimeError("Error extracting metadata: %s" % e) from e
+    except ValueError as e:
         LOGGER.exception("Error occurred: %s", e)
         raise ValueError("Error extracting metadata: %s" % e) from e

--- a/tests/unit/test_netcdf_renderer.py
+++ b/tests/unit/test_netcdf_renderer.py
@@ -7,6 +7,13 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
+# Mock optional dependencies to avoid import errors during module import
+sys.modules.setdefault("aioboto3", MagicMock())
+sys.modules.setdefault("botocore", MagicMock())
+sys.modules.setdefault("botocore.config", MagicMock())
+sys.modules.setdefault("botocore.exceptions", MagicMock())
+sys.modules.setdefault("requests", MagicMock())
+
 import numpy as np
 
 from goesvfi.integrity_check.render.netcdf import extract_metadata, render_png
@@ -184,8 +191,8 @@ class TestNetCDFRenderer(unittest.TestCase):
         # Output path
         output_path = self.base_dir / "output.png"
 
-        # Test - should raise an IOError wrapping the ValueError
-        with self.assertRaises(IOError) as context:
+        # Test - should raise a ValueError for wrong band
+        with self.assertRaises(ValueError) as context:
             render_png(self.netcdf_path, output_path)
 
         # Verify the error message
@@ -206,8 +213,8 @@ class TestNetCDFRenderer(unittest.TestCase):
         # Output path
         output_path = self.base_dir / "output.png"
 
-        # Test - should raise an IOError wrapping the ValueError
-        with self.assertRaises(IOError) as context:
+        # Test - should raise a ValueError when variable missing
+        with self.assertRaises(ValueError) as context:
             render_png(self.netcdf_path, output_path)
 
         # Verify the error message
@@ -247,10 +254,10 @@ class TestNetCDFRenderer(unittest.TestCase):
     def test_extract_metadata_error(self, mock_open_dataset):
         """Test error handling during metadata extraction."""
         # Setup
-        mock_open_dataset.side_effect = Exception("Generic error")
+        mock_open_dataset.side_effect = KeyError("Generic error")
 
         # Test
-        with self.assertRaises(ValueError):
+        with self.assertRaises(KeyError):
             extract_metadata(self.netcdf_path)
 
 


### PR DESCRIPTION
## Summary
- catch KeyError/RuntimeError/ValueError individually in netcdf renderer
- update tests to expect the specific exceptions
- add mocks for missing deps in tests

## Testing
- `python run_linters.py` *(fails: Flake8 and mypy not installed)*
- `python -m pytest tests/unit/test_netcdf_renderer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685a070c70fc8320b30d089aa8eb1a62