### PR TITLE
Finalize caching logic

### DIFF
--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -58,7 +58,8 @@ def test_load_cached_none_for_zero_frames(mock_cache_dir, sample_paths):
 
 
 def test_load_cached_cache_miss_when_files_missing(monkeypatch, sample_paths, tmp_path):
-    # Patch the config.get_cache_dir() function to return tmp_path
+    # Patch cache directory to temporary path
+    monkeypatch.setattr(cache, "CACHE_DIR", tmp_path)
     monkeypatch.setattr(config, "get_cache_dir", lambda: tmp_path)
     file1, file2 = sample_paths
     num_frames = 3


### PR DESCRIPTION
## Summary
- finish SHA-256 based cache module
- adjust error handling and use module cache directory
- update cache unit tests
- add corrupted file test

## Testing
- `python run_linters.py --flake8-only` *(fails: Flake8 found 80 issues)*
- `pytest tests/unit/test_cache.py tests/unit/test_cache_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685a0702d7b8832096c76ad63b051375