### PR TITLE
Implement partial download selection

### DIFF
--- a/goesvfi/integrity_check/enhanced_gui_tab.py
+++ b/goesvfi/integrity_check/enhanced_gui_tab.py
@@ -97,17 +97,13 @@ class FetcherConfigDialog(QDialog):
         fallback_layout = QFormLayout()
 
         self.fallback_strategy = QComboBox()
-        self.fallback_strategy.addItems(
-            ["CDN first, then S3", "S3 first, then CDN", "CDN only", "S3 only"]
-        )
+        self.fallback_strategy.addItems(["CDN first, then S3", "S3 first, then CDN", "CDN only", "S3 only"])
         fallback_layout.addRow("Fallback Strategy:", self.fallback_strategy)
 
         layout.addLayout(fallback_layout)
 
         # Dialog buttons
-        buttons = QDialogButtonBox(
-            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
-        )
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
         layout.addWidget(buttons)
@@ -204,9 +200,7 @@ class EnhancedIntegrityCheckTab(IntegrityCheckTab):
         if control_layout:
             # Add fetcher configuration button with improved styling
             self.configure_fetchers_btn = QPushButton("⚙ Configure")
-            self.configure_fetchers_btn.setToolTip(
-                "Configure CDN and S3 fetching options"
-            )
+            self.configure_fetchers_btn.setToolTip("Configure CDN and S3 fetching options")
             self.configure_fetchers_btn.setMaximumWidth(100)
             self.configure_fetchers_btn.clicked.connect(self._show_fetcher_config)
             control_layout.addWidget(self.configure_fetchers_btn)
@@ -285,11 +279,7 @@ class EnhancedIntegrityCheckTab(IntegrityCheckTab):
 
         try:
             # Check if we should simulate an error (for test compatibility)
-            if (
-                self.view_model
-                and hasattr(self.view_model, "base_directory")
-                and self.view_model.base_directory
-            ):
+            if self.view_model and hasattr(self.view_model, "base_directory") and self.view_model.base_directory:
                 from goesvfi.integrity_check.time_index import TimeIndex
 
                 # This will raise an exception if the test has mocked it to do so
@@ -298,13 +288,9 @@ class EnhancedIntegrityCheckTab(IntegrityCheckTab):
                     if self.view_model and hasattr(self.view_model, "satellite")
                     else SatellitePattern.GOES_16
                 )
-                TimeIndex.find_date_range_in_directory(
-                    Path(self.view_model.base_directory), satellite
-                )
+                TimeIndex.find_date_range_in_directory(Path(self.view_model.base_directory), satellite)
 
-                base_dir = (
-                    Path(self.view_model.base_directory) if self.view_model else Path()
-                )
+                base_dir = Path(self.view_model.base_directory) if self.view_model else Path()
                 if base_dir.exists():
                     # Check if directory is empty
                     files = list(base_dir.rglob("*"))
@@ -365,17 +351,13 @@ class EnhancedIntegrityCheckTab(IntegrityCheckTab):
         super()._perform_scan()
 
         # Additional logging for enhanced features
-        LOGGER.info(
-            "Using fetcher strategy: %s", self.fetcher_config["fallback_strategy"]
-        )
+        LOGGER.info("Using fetcher strategy: %s", self.fetcher_config["fallback_strategy"])
 
     def _download_selected(self) -> None:
         """Override download to use enhanced fetching based on configuration."""
         selected_items = self._get_selected_items()
         if not selected_items:
-            QMessageBox.warning(
-                self, "No Selection", "Please select items to download."
-            )
+            QMessageBox.warning(self, "No Selection", "Please select items to download.")
             return
 
         LOGGER.info("Starting enhanced download for %d items", len(selected_items))
@@ -411,14 +393,11 @@ class EnhancedIntegrityCheckTab(IntegrityCheckTab):
             )
             return
 
-        # Use the first store as primary, others as fallback
-        # This could be enhanced to use a composite store pattern
-        primary_store = stores[0]
-
-        # For now, use the parent's download method
-        # In a real implementation, we would override the view model's
-        # download method to use our configured stores
-        super()._download_selected()
+        # Trigger download for the selected items
+        if self.view_model:
+            self.view_model.start_downloads(selected_items)
+        else:
+            self.status_label.setText("Error: No view model connected")
 
     def get_scan_summary(self) -> Dict[str, Any]:
         """Get a summary of the current scan results."""
@@ -503,24 +482,16 @@ class EnhancedIntegrityCheckTab(IntegrityCheckTab):
 
         # Connect signals - use toggled instead of buttonClicked for programmatic changes
         self.auto_radio.toggled.connect(
-            lambda checked: (
-                self._on_fetch_source_changed(self.auto_radio) if checked else None
-            )
+            lambda checked: (self._on_fetch_source_changed(self.auto_radio) if checked else None)
         )
         self.cdn_radio.toggled.connect(
-            lambda checked: (
-                self._on_fetch_source_changed(self.cdn_radio) if checked else None
-            )
+            lambda checked: (self._on_fetch_source_changed(self.cdn_radio) if checked else None)
         )
         self.s3_radio.toggled.connect(
-            lambda checked: (
-                self._on_fetch_source_changed(self.s3_radio) if checked else None
-            )
+            lambda checked: (self._on_fetch_source_changed(self.s3_radio) if checked else None)
         )
         self.local_radio.toggled.connect(
-            lambda checked: (
-                self._on_fetch_source_changed(self.local_radio) if checked else None
-            )
+            lambda checked: (self._on_fetch_source_changed(self.local_radio) if checked else None)
         )
 
     def _add_satellite_radios(self) -> None:
@@ -549,9 +520,7 @@ class EnhancedIntegrityCheckTab(IntegrityCheckTab):
 
         # Add auto-detect button with improved styling
         self.auto_detect_btn = QPushButton("🔍 Auto-Detect")
-        self.auto_detect_btn.setToolTip(
-            "Automatically detect which satellite has more files"
-        )
+        self.auto_detect_btn.setToolTip("Automatically detect which satellite has more files")
         self.auto_detect_btn.setMaximumWidth(120)
         self.auto_detect_btn.clicked.connect(self._auto_detect_satellite)
         radio_layout.addWidget(self.auto_detect_btn)
@@ -569,14 +538,10 @@ class EnhancedIntegrityCheckTab(IntegrityCheckTab):
 
         # Connect signals - use toggled instead of buttonClicked for programmatic changes
         self.goes16_radio.toggled.connect(
-            lambda checked: (
-                self._on_satellite_changed(self.goes16_radio) if checked else None
-            )
+            lambda checked: (self._on_satellite_changed(self.goes16_radio) if checked else None)
         )
         self.goes18_radio.toggled.connect(
-            lambda checked: (
-                self._on_satellite_changed(self.goes18_radio) if checked else None
-            )
+            lambda checked: (self._on_satellite_changed(self.goes18_radio) if checked else None)
         )
 
     def _on_fetch_source_changed(self, button: QRadioButton) -> None:
@@ -605,9 +570,7 @@ class EnhancedIntegrityCheckTab(IntegrityCheckTab):
     def _auto_detect_satellite(self) -> None:
         """Auto-detect which satellite has more files in the directory."""
         if not self.view_model or not hasattr(self.view_model, "base_directory"):
-            QMessageBox.warning(
-                self, "No Directory", "Please select a directory first."
-            )
+            QMessageBox.warning(self, "No Directory", "Please select a directory first.")
             return
 
         # Create progress dialog but don't make it modal in test environments
@@ -616,9 +579,7 @@ class EnhancedIntegrityCheckTab(IntegrityCheckTab):
             # Check if we're in a test environment by looking for mocked QProgressDialog
 
             if QProgressDialog.__module__ != "unittest.mock":
-                progress_dialog = QProgressDialog(
-                    "Scanning directory...", "Cancel", 0, 0, self
-                )
+                progress_dialog = QProgressDialog("Scanning directory...", "Cancel", 0, 0, self)
                 progress_dialog.setWindowTitle("Auto-Detecting Satellite")
                 progress_dialog.setModal(False)  # Non-modal to avoid blocking
                 progress_dialog.setMinimumDuration(0)  # Show immediately
@@ -630,9 +591,7 @@ class EnhancedIntegrityCheckTab(IntegrityCheckTab):
 
         try:
             # Log the scan start
-            LOGGER.info(
-                f"Auto-detect satellite: Starting scan of directory {self.view_model.base_directory}"
-            )
+            LOGGER.info(f"Auto-detect satellite: Starting scan of directory {self.view_model.base_directory}")
 
             # Simple file counting approach to avoid TimeIndex complexity
             base_path = Path(self.view_model.base_directory)
@@ -642,9 +601,7 @@ class EnhancedIntegrityCheckTab(IntegrityCheckTab):
             goes18_count = 0
 
             # Log scanning for each satellite
-            LOGGER.info(
-                f"Auto-detect satellite: Scanning for GOES-16 files in {base_path}"
-            )
+            LOGGER.info(f"Auto-detect satellite: Scanning for GOES-16 files in {base_path}")
 
             # Scan all PNG files in the directory and subdirectories
             for png_file in base_path.rglob("*.png"):
@@ -661,9 +618,7 @@ class EnhancedIntegrityCheckTab(IntegrityCheckTab):
                     return
 
             # Log found counts
-            LOGGER.info(
-                f"Auto-detect satellite: Found {goes16_count} GOES-16 files and {goes18_count} GOES-18 files"
-            )
+            LOGGER.info(f"Auto-detect satellite: Found {goes16_count} GOES-16 files and {goes18_count} GOES-18 files")
 
             if progress_dialog:
                 progress_dialog.close()
@@ -695,9 +650,7 @@ class EnhancedIntegrityCheckTab(IntegrityCheckTab):
             LOGGER.info(
                 f"Auto-detect satellite: Selected {detected} based on file count ({goes16_count if detected == 'GOES-16' else goes18_count} vs {goes18_count if detected == 'GOES-16' else goes16_count})"
             )
-            LOGGER.info(
-                f"Auto-detect satellite: Completed successfully, selected {detected_full}"
-            )
+            LOGGER.info(f"Auto-detect satellite: Completed successfully, selected {detected_full}")
 
             # Show result
             QMessageBox.information(
@@ -728,9 +681,7 @@ class EnhancedIntegrityCheckTab(IntegrityCheckTab):
         formatted_message = f'<span style="color: {color};">{message}</span>'
         self.status_label.setText(formatted_message)
 
-    def _update_progress(
-        self, current: int, total: int, eta_seconds: float = 0.0
-    ) -> None:
+    def _update_progress(self, current: int, total: int, eta_seconds: float = 0.0) -> None:
         """Update the progress bar with detailed information."""
         # Update progress bar value
         if total > 0:

--- a/tests/unit/test_enhanced_integrity_check_tab.py
+++ b/tests/unit/test_enhanced_integrity_check_tab.py
@@ -34,19 +34,11 @@ class MockCDNStore:
 
 
 # Patch at the module level before any imports
-unittest.mock.patch(
-    "goesvfi.integrity_check.remote.s3_store.S3Store", MockS3Store
-).start()
-unittest.mock.patch(
-    "goesvfi.integrity_check.remote.cdn_store.CDNStore", MockCDNStore
-).start()
+unittest.mock.patch("goesvfi.integrity_check.remote.s3_store.S3Store", MockS3Store).start()
+unittest.mock.patch("goesvfi.integrity_check.remote.cdn_store.CDNStore", MockCDNStore).start()
 # Also patch in the enhanced_gui_tab module to ensure it uses our mocks
-unittest.mock.patch(
-    "goesvfi.integrity_check.enhanced_gui_tab.S3Store", MockS3Store
-).start()
-unittest.mock.patch(
-    "goesvfi.integrity_check.enhanced_gui_tab.CDNStore", MockCDNStore
-).start()
+unittest.mock.patch("goesvfi.integrity_check.enhanced_gui_tab.S3Store", MockS3Store).start()
+unittest.mock.patch("goesvfi.integrity_check.enhanced_gui_tab.CDNStore", MockCDNStore).start()
 
 from goesvfi.integrity_check.enhanced_gui_tab import (  # noqa: E402
     EnhancedIntegrityCheckTab,
@@ -277,9 +269,7 @@ class TestEnhancedIntegrityCheckTabFileOperations(PyQtAsyncTestCase):
         actual_end = self.tab.end_date_edit.dateTime().toPyDateTime()
 
         expected_start = datetime(2023, 2, 1, 0, 0, 0)
-        expected_end = datetime(
-            2023, 2, 10, 23, 59, 0
-        )  # Note: QDateTime seconds precision
+        expected_end = datetime(2023, 2, 10, 23, 59, 0)  # Note: QDateTime seconds precision
 
         assert actual_start.replace(second=0, microsecond=0) == expected_start
         assert actual_end.replace(second=0, microsecond=0) == expected_end
@@ -319,9 +309,7 @@ class TestEnhancedIntegrityCheckTabFileOperations(PyQtAsyncTestCase):
         # Mock the selection model to indicate items are selected
         mock_selection = MagicMock()
         mock_selection.hasSelection.return_value = True
-        mock_selection.selectedRows.return_value = [
-            MagicMock(row=MagicMock(return_value=0))
-        ]
+        mock_selection.selectedRows.return_value = [MagicMock(row=MagicMock(return_value=0))]
 
         # Mock the results table and model
         self.tab.results_table = MagicMock()
@@ -329,17 +317,17 @@ class TestEnhancedIntegrityCheckTabFileOperations(PyQtAsyncTestCase):
         self.tab.results_model = MagicMock()
         self.tab.results_model._items = [MagicMock()]  # At least one item
 
-        # Mock message box to return Yes for confirmation
-        mock_message_box.question.return_value = QMessageBox.StandardButton.Yes
-
         # Ensure the button is enabled
         self.tab.download_button.setEnabled(True)
 
         # Click the download button
         self.tab.download_button.click()
 
-        # Verify downloads were started on the view model
+        # Verify downloads were started on the view model with the selected item
         self.mock_view_model.start_downloads.assert_called_once()
+        args, _ = self.mock_view_model.start_downloads.call_args
+        # First arg is the item list
+        assert len(args[0]) == 1
 
     def test_cancel_download_button(self):
         """Test the cancel download button functionality."""
@@ -367,9 +355,7 @@ class TestEnhancedIntegrityCheckTabFileOperations(PyQtAsyncTestCase):
 
         # Mock table model with proper _items attribute that the handler expects
         self.tab.results_model = MagicMock()
-        self.tab.results_model._items = (
-            missing_items  # The handler checks len(self.results_model._items)
-        )
+        self.tab.results_model._items = missing_items  # The handler checks len(self.results_model._items)
 
         # Simulate the missing items being updated (which enables the download button)
         self.tab._on_missing_items_updated(missing_items)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- allow `IntegrityCheckViewModel.start_downloads` to take a list of items
- trigger downloads using selected items in `IntegrityCheckTab` and the enhanced tab
- update tests for new behaviour
- cover partial selection in integration tests

## Testing
- `pytest tests/integration/test_integrity_check_tab.py::TestIntegrityCheckTabIntegration::test_partial_download_selection -q`
- `pytest tests/unit/test_enhanced_integrity_check_tab.py::TestEnhancedIntegrityCheckTabFileOperations::test_download_all_button -q`


------
https://chatgpt.com/codex/tasks/task_e_685a073d671c83208287b9100a2e7f05