### PR TITLE
Inject managers into processing VM

### DIFF
--- a/goesvfi/gui.py
+++ b/goesvfi/gui.py
@@ -74,6 +74,7 @@ from goesvfi.utils.gui_helpers import (
     ZoomDialog,
 )
 from goesvfi.view_models.main_window_view_model import MainWindowViewModel
+from goesvfi.gui_components import PreviewManager, ProcessingManager
 
 LOGGER = log.get_logger(__name__)
 
@@ -137,9 +138,16 @@ class MainWindow(QWidget):
         # --------------
 
         # --- ViewModels ---
-        # Instantiate ViewModels here, passing required models
+        # Instantiate helper managers for the ProcessingViewModel
+        preview_manager = PreviewManager()
+        processing_manager = ProcessingManager()
+
+        # Instantiate ViewModels here, passing required models and managers
         self.main_view_model = MainWindowViewModel(
-            file_sorter_model=file_sorter_model, date_sorter_model=date_sorter_model
+            file_sorter_model=file_sorter_model,
+            date_sorter_model=date_sorter_model,
+            preview_manager=preview_manager,
+            processing_manager=processing_manager,
         )  # <-- Instantiate ViewModel with models
         self.processing_view_model = (
             self.main_view_model.processing_vm

--- a/goesvfi/view_models/main_window_view_model.py
+++ b/goesvfi/view_models/main_window_view_model.py
@@ -15,6 +15,8 @@ from goesvfi.date_sorter.view_model import DateSorterViewModel
 from goesvfi.file_sorter.sorter import FileSorter
 from goesvfi.file_sorter.view_model import FileSorterViewModel
 from goesvfi.view_models.processing_view_model import ProcessingViewModel
+from goesvfi.gui_components.preview_manager import PreviewManager
+from goesvfi.gui_components.processing_manager import ProcessingManager
 
 # Import Models
 
@@ -27,7 +29,6 @@ LOGGER = logging.getLogger(__name__)
 
 
 class MainWindowViewModel(QObject):
-    pass
     """
     ViewModel for the main application window (MainWindow).
 
@@ -45,16 +46,19 @@ class MainWindowViewModel(QObject):
         self,
         file_sorter_model: FileSorter,
         date_sorter_model: DateSorter,
-        # Add other necessary models/services here for ProcessingViewModel
+        preview_manager: PreviewManager,
+        processing_manager: ProcessingManager,
         parent: QObject | None = None,
     ) -> None:
         """
         Initializes the MainWindowViewModel and its child ViewModels.
 
         Args:
-            file_sorter_model (FileSorter): The model for the File Sorter tab.
-            date_sorter_model (DateSorter): The model for the Date Sorter tab.
-            parent (Optional[QObject]): The parent QObject, if any.
+            file_sorter_model: Model for the File Sorter tab.
+            date_sorter_model: Model for the Date Sorter tab.
+            preview_manager: PreviewManager instance used by ProcessingViewModel.
+            processing_manager: ProcessingManager instance used by ProcessingViewModel.
+            parent: Optional parent QObject.
 
         Attributes:
             pass
@@ -75,8 +79,15 @@ class MainWindowViewModel(QObject):
         LOGGER.info("FileSorterViewModel instantiated.")
         self.date_sorter_vm = DateSorterViewModel(date_sorter_model)
         LOGGER.info("DateSorterViewModel instantiated.")
-        # TODO: Pass necessary models/services to ProcessingViewModel when defined
-        self.processing_vm = ProcessingViewModel(parent=self)
+
+        self.preview_manager = preview_manager
+        self.processing_manager = processing_manager
+
+        self.processing_vm = ProcessingViewModel(
+            preview_manager=preview_manager,
+            processing_manager=processing_manager,
+            parent=self,
+        )
         LOGGER.info("ProcessingViewModel instantiated.")
 
         # Initialize global state properties
@@ -106,7 +117,6 @@ class MainWindowViewModel(QObject):
             value (str): The new status message.
         """
         if self._status != value:
-            pass
             self._status = value  # pylint: disable=attribute-defined-outside-init
             self.status_updated.emit(self._status)
             LOGGER.debug("Global status updated: %s", self._status)
@@ -130,7 +140,6 @@ class MainWindowViewModel(QObject):
             index (int): The new active tab index.
         """
         if self._active_tab_index != index:
-            pass
             self._active_tab_index = (
                 index  # pylint: disable=attribute-defined-outside-init
             )

--- a/goesvfi/view_models/processing_view_model.py
+++ b/goesvfi/view_models/processing_view_model.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Optional
 
+from goesvfi.gui_components.preview_manager import PreviewManager
+from goesvfi.gui_components.processing_manager import ProcessingManager
+
 from PyQt6.QtCore import QObject, pyqtSignal
 
 from goesvfi.pipeline.ffmpeg_builder import FFmpegCommandBuilder
@@ -30,14 +33,18 @@ class ProcessingViewModel(QObject):
     progress_updated = pyqtSignal(int, int, float)  # current, total, eta_seconds
     processing_finished = pyqtSignal(bool, str)  # success/failure, message
 
-    def __init__(self, parent: QObject | None = None) -> None:
-        """
-        Initializes the ProcessingViewModel.
-
-        Args:
-            parent (Optional[QObject]): The parent QObject, if any.
-        """
+    def __init__(
+        self,
+        preview_manager: PreviewManager,
+        processing_manager: ProcessingManager,
+        parent: QObject | None = None,
+    ) -> None:
+        """Initialize the ProcessingViewModel with dependencies."""
         super().__init__(parent)
+
+        self.preview_manager = preview_manager
+        self.processing_manager = processing_manager
+
         LOGGER.info("ProcessingViewModel initialized")
 
         # State tracking

--- a/tests/unit/test_main_window_view_model.py
+++ b/tests/unit/test_main_window_view_model.py
@@ -4,11 +4,17 @@ from PyQt6.QtCore import QObject
 from goesvfi.view_models.main_window_view_model import MainWindowViewModel
 from goesvfi.file_sorter.sorter import FileSorter
 from goesvfi.date_sorter.sorter import DateSorter
+from goesvfi.gui_components import PreviewManager, ProcessingManager
 
 
 @pytest.fixture()
 def main_window_vm(qtbot):
-    vm = MainWindowViewModel(FileSorter(), DateSorter())
+    vm = MainWindowViewModel(
+        FileSorter(),
+        DateSorter(),
+        PreviewManager(),
+        ProcessingManager(),
+    )
     yield vm
     vm.deleteLater()
 
@@ -25,3 +31,8 @@ def test_active_tab_signal_emitted(main_window_vm, qtbot):
         main_window_vm.active_tab_index = 1
     assert blocker.args == [1]
     assert main_window_vm.active_tab_index == 1
+
+
+def test_processing_vm_has_dependencies(main_window_vm):
+    assert main_window_vm.processing_vm.preview_manager is main_window_vm.preview_manager
+    assert main_window_vm.processing_vm.processing_manager is main_window_vm.processing_manager

--- a/tests/unit/test_processing_view_model_ffmpeg.py
+++ b/tests/unit/test_processing_view_model_ffmpeg.py
@@ -1,10 +1,11 @@
 import pathlib
 
+from goesvfi.gui_components import PreviewManager, ProcessingManager
 from goesvfi.view_models.processing_view_model import ProcessingViewModel
 
 
 def test_build_ffmpeg_command_with_crop():
-    vm = ProcessingViewModel()
+    vm = ProcessingViewModel(PreviewManager(), ProcessingManager())
     output = pathlib.Path("/tmp/out.mp4")
     settings = {"encoder": "Software x264", "crf": 20, "pix_fmt": "yuv420p"}
     cmd = vm.build_ffmpeg_command(output, 30, (10, 20, 100, 80), settings)
@@ -14,8 +15,8 @@ def test_build_ffmpeg_command_with_crop():
 
 
 def test_build_ffmpeg_command_without_crop():
-    vm = ProcessingViewModel()
+    vm = ProcessingViewModel(PreviewManager(), ProcessingManager())
     output = pathlib.Path("/tmp/out.mp4")
-    settings = {"encoder": "Software x264"}
+    settings = {"encoder": "Software x264", "crf": 23}
     cmd = vm.build_ffmpeg_command(output, 24, None, settings)
     assert "-filter:v" not in cmd


### PR DESCRIPTION
## Summary
- inject PreviewManager and ProcessingManager into ProcessingViewModel
- pass these dependencies from MainWindowViewModel
- update GUI initialization
- test that dependencies are wired correctly

## Testing
- `pytest tests/unit/test_main_window_view_model.py tests/unit/test_processing_view_model_ffmpeg.py -q`
- `python run_linters.py goesvfi/view_models/processing_view_model.py goesvfi/view_models/main_window_view_model.py goesvfi/gui.py tests/unit/test_main_window_view_model.py tests/unit/test_processing_view_model_ffmpeg.py`

------
https://chatgpt.com/codex/tasks/task_e_685a0722f5c4832081e9cf23a7877e51