### PR TITLE
Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- enable Dependabot for pip dependencies

## Testing
- `pre-commit run --files .github/dependabot.yml`
- `python run_non_gui_tests_ci.py` *(fails: AttributeError: QFileDialog)*

------
https://chatgpt.com/codex/tasks/task_e_685c1b090cfc832086edef1d4732a94f