### PR TITLE
Add FFmpeg minterpolate support with tests

### DIFF
--- a/goesvfi/pipeline/run_ffmpeg.py
+++ b/goesvfi/pipeline/run_ffmpeg.py
@@ -1,6 +1,12 @@
+"""Helper utilities to run FFmpeg based interpolation."""
+
+from __future__ import annotations
+
 import logging
 from pathlib import Path
 from typing import Optional, Tuple
+
+from .encode import _run_ffmpeg_command
 
 LOGGER = logging.getLogger(__name__)
 
@@ -36,14 +42,102 @@ def run_ffmpeg_interpolation(
     bufsize_kb: int,
     pix_fmt: str,
 ) -> Path:
-    """
-    Stub for FFmpeg interpolation pipeline.
-    Currently not implemented.
+    """Run FFmpeg interpolation using the minterpolate filter.
 
-    TODO: This is a placeholder for future FFmpeg-based interpolation implementation.
-    The implementation would use FFmpeg's minterpolate filter to generate intermediate
-    frames between input frames, with various options for motion estimation and
-    interpolation algorithms.
+    This function builds an FFmpeg command based on the provided parameters and
+    executes it using the common ``_run_ffmpeg_command`` helper.  It supports
+    optional cropping, minterpolate settings and unsharp filtering.
     """
-    LOGGER.error("FFmpeg interpolation pipeline not implemented yet.")
-    raise NotImplementedError("FFmpeg interpolation pipeline not implemented yet")
+
+    if not input_dir.is_dir():
+        raise ValueError(f"Input directory {input_dir} does not exist")
+
+    images = sorted(input_dir.glob("*.png"))
+    if not images:
+        raise ValueError(f"No PNG files found in {input_dir}")
+
+    loglevel = "debug" if debug_mode else "info"
+
+    cmd = [
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        loglevel,
+        "-y",
+        "-framerate",
+        str(fps),
+        "-pattern_type",
+        "glob",
+        "-i",
+        str(input_dir / "*.png"),
+    ]
+
+    filter_parts = []
+
+    if crop_rect:
+        x, y, w, h = crop_rect
+        filter_parts.append(f"crop={w}:{h}:{x}:{y}")
+
+    target_fps = fps * (num_intermediate_frames + 1)
+
+    if use_ffmpeg_interp:
+        interp_options = [
+            f"fps={target_fps}",
+            f"mi_mode={mi_mode}",
+            f"mc_mode={mc_mode}",
+            f"me_mode={me_mode}",
+        ]
+        if me_algo and me_algo != "(default)":
+            interp_options.append(f"me={me_algo}")
+        if search_param:
+            interp_options.append(f"search_param={search_param}")
+        if scd_mode:
+            interp_options.append(f"scd={scd_mode}")
+        if scd_threshold is not None:
+            interp_options.append(f"scd_threshold={scd_threshold}")
+        if minter_mb_size is not None:
+            interp_options.append(f"mb_size={minter_mb_size}")
+        if minter_vsbmc:
+            interp_options.append("vsbmc=1")
+        filter_parts.append("minterpolate=" + ":".join(interp_options))
+
+    if apply_unsharp:
+        filter_parts.append(
+            f"unsharp={unsharp_lx}:{unsharp_ly}:{unsharp_la}:{unsharp_cx}:{unsharp_cy}:{unsharp_ca}"
+        )
+
+    filter_parts.append("scale=trunc(iw/2)*2:trunc(ih/2)*2")
+
+    filter_str = ",".join(filter_parts)
+
+    cmd.extend(
+        [
+            "-vf",
+            filter_str,
+            "-an",
+            "-vcodec",
+            "libx264",
+            "-preset",
+            filter_preset,
+            "-crf",
+            str(crf),
+        ]
+    )
+
+    if bitrate_kbps:
+        cmd.extend(["-b:v", f"{bitrate_kbps}k"])
+    if bufsize_kb:
+        cmd.extend(["-bufsize", f"{bufsize_kb}k"])
+
+    cmd.extend(["-pix_fmt", pix_fmt, str(output_mp4_path)])
+
+    LOGGER.info("Running FFmpeg command: %s", " ".join(cmd))
+
+    try:
+        _run_ffmpeg_command(cmd, "FFmpeg interpolation", monitor_memory=False)
+    except Exception as exc:  # pragma: no cover - unexpected
+        LOGGER.error("FFmpeg interpolation failed: %s", exc)
+        raise
+
+    LOGGER.info("Interpolation completed: %s", output_mp4_path)
+    return output_mp4_path

--- a/tests/integration/test_run_ffmpeg_interpolation.py
+++ b/tests/integration/test_run_ffmpeg_interpolation.py
@@ -1,0 +1,109 @@
+import pathlib
+from unittest.mock import patch
+
+import pathlib
+import pytest
+
+from goesvfi.pipeline.run_ffmpeg import run_ffmpeg_interpolation
+from tests.utils.helpers import create_dummy_png
+
+
+def _create_inputs(tmp_path: pathlib.Path, count: int = 2) -> pathlib.Path:
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    for i in range(count):
+        create_dummy_png(input_dir / f"frame_{i}.png", size=(8, 8))
+    return input_dir
+
+
+def test_ffmpeg_interpolation_success(tmp_path: pathlib.Path):
+    input_dir = _create_inputs(tmp_path)
+    output_file = tmp_path / "out.mp4"
+    captured = {}
+
+    def fake_run(cmd, desc, monitor_memory=False):
+        captured["cmd"] = cmd
+        output_file.write_text("done")
+
+    with patch("goesvfi.pipeline.run_ffmpeg._run_ffmpeg_command", side_effect=fake_run) as mock_run:
+        result = run_ffmpeg_interpolation(
+            input_dir=input_dir,
+            output_mp4_path=output_file,
+            fps=30,
+            num_intermediate_frames=1,
+            _use_preset_optimal=False,
+            crop_rect=(0, 0, 4, 4),
+            debug_mode=False,
+            use_ffmpeg_interp=True,
+            filter_preset="fast",
+            mi_mode="mci",
+            mc_mode="obmc",
+            me_mode="bidir",
+            me_algo="",
+            search_param=32,
+            scd_mode="fdiff",
+            scd_threshold=10.0,
+            minter_mb_size=None,
+            minter_vsbmc=0,
+            apply_unsharp=False,
+            unsharp_lx=5,
+            unsharp_ly=5,
+            unsharp_la=1.0,
+            unsharp_cx=5,
+            unsharp_cy=5,
+            unsharp_ca=0.0,
+            crf=18,
+            bitrate_kbps=1000,
+            bufsize_kb=1500,
+            pix_fmt="yuv420p",
+        )
+
+    assert result == output_file
+    assert output_file.exists()
+    cmd_str = " ".join(captured["cmd"])
+    assert "minterpolate" in cmd_str
+    assert "crop=4:4:0:0" in cmd_str
+    mock_run.assert_called_once()
+
+
+def test_ffmpeg_interpolation_failure(tmp_path: pathlib.Path):
+    input_dir = _create_inputs(tmp_path)
+    output_file = tmp_path / "out.mp4"
+
+    def fail_run(*_a, **_k):
+        raise RuntimeError("ffmpeg failed")
+
+    with patch("goesvfi.pipeline.run_ffmpeg._run_ffmpeg_command", side_effect=fail_run):
+        with pytest.raises(RuntimeError):
+            run_ffmpeg_interpolation(
+                input_dir=input_dir,
+                output_mp4_path=output_file,
+                fps=30,
+                num_intermediate_frames=1,
+                _use_preset_optimal=False,
+                crop_rect=None,
+                debug_mode=False,
+                use_ffmpeg_interp=True,
+                filter_preset="fast",
+                mi_mode="mci",
+                mc_mode="obmc",
+                me_mode="bidir",
+                me_algo="",
+                search_param=32,
+                scd_mode="fdiff",
+                scd_threshold=10.0,
+                minter_mb_size=None,
+                minter_vsbmc=0,
+                apply_unsharp=False,
+                unsharp_lx=5,
+                unsharp_ly=5,
+                unsharp_la=1.0,
+                unsharp_cx=5,
+                unsharp_cy=5,
+                unsharp_ca=0.0,
+                crf=18,
+                bitrate_kbps=1000,
+                bufsize_kb=1500,
+                pix_fmt="yuv420p",
+            )
+


### PR DESCRIPTION
## Summary
- implement `run_ffmpeg_interpolation` using FFmpeg's `minterpolate`
- allow cropping/unsharp options and build filter chain
- add integration tests covering success and failure cases

## Testing
- `python run_linters.py --flake8-only`
- `pytest tests/integration/test_run_ffmpeg_interpolation.py -v`

------
https://chatgpt.com/codex/tasks/task_e_685d71f06df4832090dfc315b9b34f5e