### PR TITLE
Improve tile blending with overlap

### DIFF
--- a/goesvfi/pipeline/tiler.py
+++ b/goesvfi/pipeline/tiler.py
@@ -5,14 +5,25 @@ from typing import List, Tuple
 import numpy as np
 from numpy.typing import NDArray
 
-# TODO: split/merge with overlap
-
 
 def tile_image(
     img: NDArray[np.float32], tile_size: int = 2048, overlap: int = 32
 ) -> List[Tuple[int, int, NDArray[np.float32]]]:
-    """Split H×W×3 image into overlapping RGB float32 tiles."""
+    """Split H×W×3 image into overlapping RGB float32 tiles.
+
+    Parameters
+    ----------
+    img:
+        Full image to tile in H×W×3 format.
+    tile_size:
+        Size of the square tile. The actual tile may be smaller at the image
+        edges.
+    overlap:
+        Amount of overlap in pixels between tiles. Set to 0 for no overlap.
+    """
+
     h, w, _ = img.shape
+    step = tile_size - overlap if overlap < tile_size else tile_size
     tiles: List[Tuple[int, int, NDArray[np.float32]]] = []
     y = 0
     while y < h:
@@ -22,8 +33,8 @@ def tile_image(
             w_end = min(x + tile_size, w)
             tile = img[y:h_end, x:w_end, :].copy()
             tiles.append((x, y, tile))
-            x += tile_size - overlap
-        y += tile_size - overlap
+            x += step
+        y += step
     return tiles
 
 
@@ -32,13 +43,35 @@ def merge_tiles(
     full_shape: Tuple[int, int],
     overlap: int = 32,
 ) -> NDArray[np.float32]:
+    """Merge tiles back into a single image with optional edge blending."""
     H, W = full_shape
     canvas = np.zeros((H, W, 3), dtype=np.float32)
     weight = np.zeros((H, W, 1), dtype=np.float32)
+
     for x, y, tile in tiles:
         h, w, _ = tile.shape
-        alpha = np.ones((h, w, 1), dtype=np.float32)
-        canvas[y : y + h, x : x + w] += tile * alpha
-        weight[y : y + h, x : x + w] += alpha
+        mask_y = np.ones(h, dtype=np.float32)
+        mask_x = np.ones(w, dtype=np.float32)
+
+        if overlap > 0:
+            if y > 0:
+                o = min(overlap, h)
+                mask_y[:o] = np.linspace(0, 1, o, endpoint=False)
+            if y + h < H:
+                o = min(overlap, h)
+                mask_y[h - o :] = np.linspace(1, 0, o, endpoint=False)
+            if x > 0:
+                o = min(overlap, w)
+                mask_x[:o] = np.linspace(0, 1, o, endpoint=False)
+            if x + w < W:
+                o = min(overlap, w)
+                mask_x[w - o :] = np.linspace(1, 0, o, endpoint=False)
+
+        mask = mask_y[:, None] * mask_x[None, :]
+        mask = mask[..., None]
+
+        canvas[y : y + h, x : x + w] += tile * mask
+        weight[y : y + h, x : x + w] += mask
+
     canvas /= np.maximum(weight, 1e-5)
     return canvas

--- a/tests/unit/test_tiler.py
+++ b/tests/unit/test_tiler.py
@@ -76,3 +76,13 @@ def test_merge_tiles_with_overlap():
     # Since original image is all ones, merged should be all ones
     assert merged.shape == img.shape
     assert np.allclose(merged, img, atol=1e-6)
+
+
+def test_lossless_reconstruction_random():
+    """Verify tiling and merging with overlap reconstructs the image exactly."""
+    img = np.random.rand(256, 256, 3).astype(np.float32)
+    tiles = tile_image(img, tile_size=128, overlap=32)
+    merged = merge_tiles(tiles, full_shape=(img.shape[0], img.shape[1]), overlap=32)
+
+    assert merged.shape == img.shape
+    assert np.allclose(merged, img, atol=1e-6)


### PR DESCRIPTION
## Summary
- blend overlapping image tiles for seamless merging
- verify lossless reconstruction with new unit test

## Testing
- `python -m pytest tests/unit/test_tiler.py -v`


------
https://chatgpt.com/codex/tasks/task_e_685d71e6467483208f1538a94e368b32